### PR TITLE
fix: redirect on session expiry

### DIFF
--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -23,6 +23,14 @@ async function request(endpoint, options = {}) {
 
     const response = await fetch(`${BASE_URL}${endpoint}`, config)
 
+    if (response.status === 401) {
+        authStore.logout()
+        sessionStorage.removeItem('dashboardArticles')
+        sessionStorage.removeItem('selectedProfileId')
+        window.location.replace('/login?reason=session-expired')
+        throw new Error('Session expired. Please log in again.')
+    }
+
     if (!response.ok) {
         const error = await response.json().catch(() => ({ detail: 'Request failed' }))
         throw new Error(error.detail || `HTTP ${response.status}`)

--- a/frontend/src/views/Login.vue
+++ b/frontend/src/views/Login.vue
@@ -65,11 +65,12 @@
 </template>
 
 <script setup>
-import { ref } from 'vue'
-import { useRouter } from 'vue-router'
+import { ref, onMounted } from 'vue'
+import { useRouter, useRoute } from 'vue-router'
 import { useAuthStore } from '../stores/auth'
 import { useDashboardStore } from '../stores/dashboard'
 import { Mail, Lock, AlertCircle, LogIn } from 'lucide-vue-next'
+import { useToast } from '@/utils/shareUtils'
 
 const email = ref('')
 const password = ref('')
@@ -77,8 +78,17 @@ const error = ref('')
 const loading = ref(false)
 
 const router = useRouter()
+const route = useRoute()
 const authStore = useAuthStore()
 const dashboardStore = useDashboardStore()
+const { show } = useToast()
+
+onMounted(() => {
+  if (route.query?.reason === 'session-expired') {
+    show('Session expired. Please sign in again.', 'error')
+    router.replace({ query: {} })
+  }
+})
 
 async function handleLogin() {
   error.value = ''

--- a/logs/session_progress_2026-01-29.md
+++ b/logs/session_progress_2026-01-29.md
@@ -1,0 +1,17 @@
+# Session Progress - 2026-01-29
+
+## Executive Summary
+- Added a global 401 handler to redirect to login and clear cached article context.
+- Added a login toast for session-expired redirects.
+- Restarted dev servers to apply frontend changes.
+
+## Changes
+- Updated API request helper to detect session expiry, clear session-scoped article data, and force navigation to login: `frontend/src/services/api.js`.
+- Added a session-expired toast on login and cleared the query flag after showing: `frontend/src/views/Login.vue`.
+
+## Verification
+- Dev servers restarted via `bash scripts/restart-dev.sh`.
+- No automated tests run.
+
+## Commits
+- No commits created.


### PR DESCRIPTION
## Summary
- redirect expired sessions to login and clear cached article context
- show a session-expired toast on the login screen
- add session log for 2026-01-29